### PR TITLE
Revert spacing between generated posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,10 +160,8 @@ async def generate_posts(message: types.Message, state: FSMContext, is_regenerat
         if not posts:
             await message.answer("Не вдалося розпізнати варіанти.\n\n" + result_string)
         else:
-            for index, post in enumerate(posts):
+            for post in posts:
                 await message.answer(post)
-                if index < len(posts) - 1:
-                    await message.answer("\u00A0", parse_mode=None)
         
         final_keyboard = InlineKeyboardMarkup(inline_keyboard=[
             [InlineKeyboardButton(text=REGENERATE_BUTTON_TEXT, callback_data="regenerate"),


### PR DESCRIPTION
## Summary
- remove the additional blank message that was sent between generated Telegram posts to restore the previous behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6d08517083268334ace510e2e58d